### PR TITLE
Fix Category Label being double-html-encoded

### DIFF
--- a/views/page/_view_header.php
+++ b/views/page/_view_header.php
@@ -36,7 +36,7 @@ if ($page->is_home) {
     <?php endif; ?>
 
     <?php if ($page->categoryPage) : ?>
-        <?= Label::primary(Helpers::truncateText(Html::encode($page->categoryPage->title), 30))
+        <?= Label::primary(Helpers::truncateText($page->categoryPage->title, 30))
             ->withLink(Link::to(null, $page->categoryPage->getUrl()))->right() ?>
     <?php endif; ?>
 


### PR DESCRIPTION
The Label class already does the HTML-encoding by itself.
This fixes the Category label being HTML-encoded twice and showing up as eg. "This &amp; That" on the rendered page