### PR TITLE
Force a space between 'last updated' and date on wiki header

### DIFF
--- a/views/page/_view_header.php
+++ b/views/page/_view_header.php
@@ -49,7 +49,7 @@ if ($page->is_home) {
 
 <div class="wiki-content-info clearfix">
     <small>
-        <?= Yii::t('WikiModule.base', 'Last updated ') . TimeAgo::widget(['timestamp' => $page->content->updated_at]) ?>
+        <?= trim(Yii::t('WikiModule.base', 'Last updated ')) . ' ' . TimeAgo::widget(['timestamp' => $page->content->updated_at]) ?>
 
         <?php if ($page->content->updatedBy !== null): ?>
             <?= Yii::t('WikiModule.base', 'by') ?>


### PR DESCRIPTION
Trim the translation to remove excess spaces and add one between the 'Last updated ' translation and the Timestamp.
Workaround for #219, although a more thorough fix might still be warranted.
The `trim()` actually is not even necessary, since HTML already de-duplicated spaces when rendering, but was added for good measure anyway.