### PR TITLE
Don't use the deprecated rich text param `maxLength`

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 1.9.1 (Unreleased)
 -------------------
 - Enh #269: Fix permission to edit wiki page from stream
+- Fix #272: Don't use the deprecated rich text param `maxLength`
 
 1.9.0 (May 1, 2023)
 -------------------

--- a/widgets/views/wallEntry.php
+++ b/widgets/views/wallEntry.php
@@ -17,7 +17,7 @@ $wikiUrl = Url::toWiki($wiki);
     <div class="wiki-preview">
         <div class="wiki-preview-content" data-ui-markdown>
             <?php if(!empty($content)) : ?>
-                <?= WikiRichText::output($content, ['maxLength' => 500, 'exclude' => ['anchor']]) ?>
+                <?= WikiRichText::preview($content, 500, ['exclude' => ['anchor']]) ?>
             <?php else: ?>
                 <?= Yii::t('WikiModule.base', 'This page is empty.') ?>
             <?php endif; ?>


### PR DESCRIPTION
Issue: https://github.com/humhub/wiki/issues/272