### PR TITLE
Fix history page, if an author of a revision was deleted

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@ Changelog
 ------------------------------
 - Enh #286: Remove option "disabled" from Wiki Page Picker
 - Enh #299: Use the custom module name in the overview page, page title and sidebar
+- Fix #316: History page crashes if an author of a revision was deleted
 
 2.0.3 (November 28, 2023)
 -------------------------

--- a/views/page/history.php
+++ b/views/page/history.php
@@ -4,12 +4,11 @@ use humhub\modules\content\components\ContentContainerActiveRecord;
 use humhub\modules\ui\view\components\View;
 use humhub\modules\wiki\helpers\Url;
 use humhub\modules\wiki\widgets\WikiContent;
-use humhub\modules\user\widgets\Image;
+use humhub\modules\wiki\widgets\WikiMenu;
 use humhub\modules\wiki\widgets\WikiPath;
 use humhub\widgets\Button;
 use humhub\widgets\Link;
 use humhub\widgets\LinkPager;
-use humhub\modules\wiki\widgets\WikiMenu;
 use humhub\widgets\TimeAgo;
 use yii\helpers\Html;
 
@@ -34,58 +33,61 @@ if ($isEnabledDiffTool) {
     <div class="panel-body">
         <div class="row">
 
-            <?php WikiContent::begin(['cssClass' => 'wiki-page-content'])?>
+            <?php WikiContent::begin(['cssClass' => 'wiki-page-content']) ?>
 
-                <div class="wiki-headline">
-                    <div class="wiki-headline-top">
-                        <?= WikiPath::widget(['page' => $page]) ?>
-                        <?= WikiMenu::widget([
-                            'object' => $page,
-                            'buttons' => WikiMenu::LINK_BACK_TO_PAGE,
-                            'blocks' => [[WikiMenu::LINK_BACK_TO_PAGE], WikiMenu::BLOCK_START],
-                        ]) ?>
-                    </div>
-                    <div class="wiki-page-title"><?= Yii::t('WikiModule.base', 'Page history') ?></div>
+            <div class="wiki-headline">
+                <div class="wiki-headline-top">
+                    <?= WikiPath::widget(['page' => $page]) ?>
+                    <?= WikiMenu::widget([
+                        'object' => $page,
+                        'buttons' => WikiMenu::LINK_BACK_TO_PAGE,
+                        'blocks' => [[WikiMenu::LINK_BACK_TO_PAGE], WikiMenu::BLOCK_START],
+                    ]) ?>
                 </div>
+                <div class="wiki-page-title"><?= Yii::t('WikiModule.base', 'Page history') ?></div>
+            </div>
 
-                <h1 class="wiki-page-history-title"><?= Html::encode($page->title) ?></h1>
+            <h1 class="wiki-page-history-title"><?= Html::encode($page->title) ?></h1>
 
-                <ul class="wiki-page-history<?php if ($isEnabledDiffTool) : ?> wiki-page-history-with-diff<?php endif; ?>" data-ui-widget="wiki.History" data-ui-init>
-                    <?php $first = true; ?>
-                    <?php foreach ($revisions as $revision): ?>
-                        <li>
-                            <div class="media">
-                                <div class="horizontal-line"><?= $isEnabledDiffTool ? Html::input('radio', 'revision_' . $revision->revision, $revision->revision) : ''; ?></div>
+            <ul class="wiki-page-history<?php if ($isEnabledDiffTool) : ?> wiki-page-history-with-diff<?php endif; ?>"
+                data-ui-widget="wiki.History" data-ui-init>
+                <?php $first = true; ?>
+                <?php foreach ($revisions as $revision): ?>
+                    <li>
+                        <div class="media">
+                            <div class="horizontal-line"><?= $isEnabledDiffTool ? Html::input('radio', 'revision_' . $revision->revision, $revision->revision) : ''; ?></div>
 
-                                <div class="media-body">
-                                    <h4 class="media-heading">
-                                        <a href="<?= $contentContainer->createUrl('view', ['title' => $page->title, 'revision' => $revision->revision]); ?>">
-                                            <?= Html::encode($page->title); ?>
-                                        </a>
-                                    </h4>
-                                    <div class="wiki-page-list-row-details">
-                                        <?= TimeAgo::widget(['timestamp' => $revision->revision]) ?>
+                            <div class="media-body">
+                                <h4 class="media-heading">
+                                    <a href="<?= $contentContainer->createUrl('view', ['title' => $page->title, 'revision' => $revision->revision]); ?>">
+                                        <?= Html::encode($page->title); ?>
+                                    </a>
+                                </h4>
+                                <div class="wiki-page-list-row-details">
+                                    <?= TimeAgo::widget(['timestamp' => $revision->revision]) ?>
+                                    <?php if ($revision->author): ?>
                                         &middot; <?= \humhub\libs\Html::containerLink($revision->author) ?>
-                                        &middot; <?= Link::to(Yii::t('WikiModule.base', 'show changes'), Url::toWiki($page, $revision))->cssClass('wiki-page-view-link') ?>
-                                    </div>
-
+                                    <?php endif; ?>
+                                    &middot; <?= Link::to(Yii::t('WikiModule.base', 'show changes'), Url::toWiki($page, $revision))->cssClass('wiki-page-view-link') ?>
                                 </div>
 
                             </div>
-                        </li>
-                        <?php $first = false; ?>
-                    <?php endforeach; ?>
 
-                    <div class="text-center">
-                        <?= LinkPager::widget(['pagination' => $pagination]); ?>
-                    </div>
-                </ul>
+                        </div>
+                    </li>
+                    <?php $first = false; ?>
+                <?php endforeach; ?>
 
-                <?php if ($isEnabledDiffTool) : ?>
-                    <?= Button::primary(Yii::t('WikiModule.base', 'Compare changes'))
-                        ->action('wiki.History.compare')
-                        ->cssClass('wiki-page-history-btn-compare') ?>
-                <?php endif; ?>
+                <div class="text-center">
+                    <?= LinkPager::widget(['pagination' => $pagination]); ?>
+                </div>
+            </ul>
+
+            <?php if ($isEnabledDiffTool) : ?>
+                <?= Button::primary(Yii::t('WikiModule.base', 'Compare changes'))
+                    ->action('wiki.History.compare')
+                    ->cssClass('wiki-page-history-btn-compare') ?>
+            <?php endif; ?>
 
             <?php WikiContent::end() ?>
         </div>


### PR DESCRIPTION
When viewing the history of a wiki page, if an author of a revision was deleted, the page crashes