### PR TITLE
Fix: Type error when viewing a pending delete page

### DIFF
--- a/controllers/PageController.php
+++ b/controllers/PageController.php
@@ -59,11 +59,6 @@ class PageController extends BaseController
     public function actionView(int $id = null, $revisionId = null)
     {
         $page = $this->getWikiPage($id);
-
-        if (!$page && $this->canCreatePage()) {
-            return $this->redirect(Url::toWikiEdit($page));
-        }
-
         if (!$page) {
             throw new HttpException(404, 'Wiki page not found!');
         }
@@ -74,13 +69,6 @@ class PageController extends BaseController
         }
 
         $revision = $this->getRevision($page, $revisionId);
-
-        // There is no revision for this page.
-        if (!$revision && $this->canCreatePage()) {
-            $page->delete();
-            return $this->redirect(Url::toWikiEdit($page));
-        }
-
         if (!$revision) {
             $page->delete();
             throw new HttpException(404, 'Wiki page revision not found!');
@@ -111,6 +99,7 @@ class PageController extends BaseController
             throw new InvalidArgumentException('Invalid $id parameter given!');
         }
 
+        /** @var WikiPage $wikiPage */
         $wikiPage = WikiPage::find()
             ->contentContainer($this->contentContainer)
             ->readable()

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+Unreleased
+---------------------
+- Fix: Type error when viewing a pending delete page
+
 2.3.0 (April 22, 2024)
 ---------------------
 - Enh #256: Allow Wiki pages with the same name

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,7 +3,7 @@ Changelog
 
 Unreleased
 ---------------------
-- Fix: Type error when viewing a pending delete page
+- Fix #328: Type error when viewing a pending delete page
 
 2.3.0 (April 22, 2024)
 ---------------------


### PR DESCRIPTION
`Url::toWikiEdit()` cannot have a `null` passed as argument.
And there is no point editing a deleted page.