### PR TITLE
Fix: Old URLs don't work since version 2.3.0

### DIFF
--- a/components/WikiPageUrlRule.php
+++ b/components/WikiPageUrlRule.php
@@ -11,6 +11,7 @@ namespace humhub\modules\wiki\components;
 use humhub\components\ContentContainerUrlRuleInterface;
 use humhub\modules\content\components\ContentContainerActiveRecord;
 use humhub\modules\wiki\models\WikiPage;
+use Yii;
 use yii\base\Component;
 use yii\base\Exception;
 use yii\web\UrlManager;
@@ -42,10 +43,16 @@ class WikiPageUrlRule extends Component implements UrlRuleInterface, ContentCont
 
             if ((string)$id === $parts[1]) { // the value after wiki/ doesn't contain other char than numbers
                 $wikiPage = $query->andWhere(['wiki_page.id' => $id])->one();
-            } elseif (count($parts) === 2) { // Fallback for old URLs (without ID)
-                $title = $parts[1];
-                /* @var $wikiPage WikiPage */
-                $wikiPage = $query->andWhere(['wiki_page.title' => $title])->one();
+            } else {
+                if (count($parts) === 2) { // Fallback for old URLs without ID
+                    $title = $parts[1];
+                } else { // Fallback for old URLs with `/page/view?title=`
+                    $title = Yii::$app->request->get('title');
+                }
+                if ($title) {
+                    /* @var $wikiPage WikiPage */
+                    $wikiPage = $query->andWhere(['wiki_page.title' => $title])->one();
+                }
             }
 
             if ($wikiPage !== null) {

--- a/controllers/PageController.php
+++ b/controllers/PageController.php
@@ -18,7 +18,6 @@ use humhub\modules\wiki\permissions\ViewHistory;
 use Throwable;
 use Yii;
 use yii\base\Exception;
-use yii\base\InvalidArgumentException;
 use yii\base\InvalidConfigException;
 use yii\db\StaleObjectException;
 use yii\web\HttpException;
@@ -96,7 +95,7 @@ class PageController extends BaseController
     private function getWikiPage($id): ?WikiPage
     {
         if (!is_int($id)) {
-            throw new InvalidArgumentException('Invalid $id parameter given!');
+            return null;
         }
 
         /** @var WikiPage $wikiPage */

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 Unreleased
 ---------------------
 - Fix #328: Type error when viewing a pending delete page
+- Fix: Old URLs don't work since version 2.3.0
 
 2.3.0 (April 22, 2024)
 ---------------------


### PR DESCRIPTION
Issue https://github.com/humhub/humhub-internal/issues/261