### PR TITLE
Wiki-tree-editing-toggle-button

### DIFF
--- a/controllers/OverviewController.php
+++ b/controllers/OverviewController.php
@@ -113,4 +113,16 @@ class OverviewController extends BaseController
     {
         $this->updateFoldingState($categoryId, $state);
     }
+
+    public function actionToggleWikiTreeEditing()
+    {
+        $module = Yii::$app->getModule('wiki');
+        $user = Yii::$app->user->identity;
+        $editingEnabled = $module->settings->contentContainer($user)->get('wikiTreeEditingEnabled');
+
+        $newState = !$editingEnabled;
+        $module->settings->contentContainer($user)->set('wikiTreeEditingEnabled', $newState);
+
+        return $this->redirect(Url::toOverview($this->contentContainer));
+    }
 }

--- a/messages/de/base.php
+++ b/messages/de/base.php
@@ -85,4 +85,6 @@ return [
   'last update {dateTime}' => 'letztes Update {dateTime}',
   'show changes' => 'Änderungen anzeigen',
   '{userName} edited the Wiki page "{wikiPageTitle}".' => '{userName} hat die Wiki-Seite "{wikiPageTitle}" bearbeitet.',
+  'Disable wiki tree editing' => 'Bearbeitung der Seitenhierachie deaktivieren',
+  'Enable wiki tree editing' => 'Bearbeitung der Seitenhierachie  aktivieren',
 ];

--- a/tests/codeception/functional/WikiTreeEditingButtonCest.php
+++ b/tests/codeception/functional/WikiTreeEditingButtonCest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace wiki\functional;
+
+use humhub\modules\space\models\Space;
+use humhub\modules\wiki\helpers\Url;
+use humhub\modules\wiki\models\WikiPage;
+use humhub\modules\wiki\Module;
+use humhub\modules\user\models\User;
+use wiki\FunctionalTester;
+use Yii;
+
+class EditingButtonCest
+{
+    public function testEditingButtonHtml(FunctionalTester $I)
+    {
+        $I->wantTo('check if the wiki tree editing button toggles between enabled and disabled states at overview');
+        $space = $I->loginBySpaceUserGroup(Space::USERGROUP_ADMIN);
+        $I->enableModule($space->guid, 'wiki');
+        $category = $I->createWiki($space, 'Test Wiki Page', 'Test Wiki Page content');
+
+        $I->amOnSpace($space->guid, '/wiki/overview/list-categories');
+
+        $I->see('Enable wiki tree editing');
+        $I->dontSeeElement('.drag-icon');
+
+        $I->click('Enable wiki tree editing');
+        $I->see('Disable wiki tree editing');
+        $I->seeElement('.drag-icon');
+
+        $I->click('Disable wiki tree editing');
+        $I->see('Enable wiki tree editing');
+        $I->dontSeeElement('.drag-icon');
+    }
+
+    public function testEditingButtonVisibilityForMember(FunctionalTester $I)
+    {
+        $I->wantTo('Check if editing button is not visible for member');
+        $space = $I->loginBySpaceUserGroup(Space::USERGROUP_MEMBER);
+        $I->enableModule($space->guid, 'wiki');
+        $category = $I->createWiki($space, 'Test Wiki Page', 'Test Wiki Page content');
+
+        $I->amOnSpace($space->guid, '/wiki/overview/list-categories');
+        $I->dontSee('Enable wiki tree editing');
+        $I->dontSee('Disable wiki tree editing');
+
+    }
+
+    public function testEditingButtonVisibilityForModerator(FunctionalTester $I)
+    {
+        $I->wantTo('Check if editing button is visible for moderator');
+        $space = $I->loginBySpaceUserGroup(Space::USERGROUP_MODERATOR);
+        $I->enableModule($space->guid, 'wiki');
+        $category = $I->createWiki($space, 'Test Wiki Page', 'Test Wiki Page content');
+
+        $I->amOnSpace($space->guid, '/wiki/overview/list-categories');
+        $I->see('Enable wiki tree editing');
+    }
+}

--- a/views/overview/list-categories.php
+++ b/views/overview/list-categories.php
@@ -16,6 +16,7 @@ use humhub\modules\wiki\widgets\CategoryListView;
 use humhub\modules\wiki\widgets\WikiContent;
 use humhub\modules\wiki\widgets\WikiSearchForm;
 use humhub\widgets\Button;
+use humhub\modules\wiki\permissions\AdministerPages;
 
 /* @var $this View */
 /* @var $contentContainer ContentContainerActiveRecord */
@@ -29,6 +30,9 @@ if (Helper::isEnterpriseTheme()) {
 }
 
 $settings = new DefaultSettings(['contentContainer' => $contentContainer]);
+$module = Yii::$app->getModule('wiki');    
+$user = Yii::$app->user->identity;
+$editingEnabled = $module->settings->contentContainer($user)->get('wikiTreeEditingEnabled', FALSE);
 ?>
 <div class="panel panel-default">
     <div class="panel-body">
@@ -38,6 +42,7 @@ $settings = new DefaultSettings(['contentContainer' => $contentContainer]);
                 <h3><?= Html::encode($settings->module_label) ?></h3>
                 <?= WikiSearchForm::widget(['contentContainer' => $contentContainer, 'cssClass' => 'pull-left']) ?>
                 <div class="wiki-page-content-header-actions">
+                    <?= Button::info($editingEnabled ? Yii::t('WikiModule.base', 'Disable wiki tree editing') : Yii::t('WikiModule.base', 'Enable wiki tree editing'))->sm()->link(Url::current(['toggle-wiki-tree-editing']))->visible($contentContainer->can(AdministerPages::class))?>
                     <?= Button::info(Yii::t('WikiModule.base', 'Last edited'))->sm()->link(Url::toLastEdited($contentContainer))->cssClass(Helper::isEnterpriseTheme() ? 'hidden-lg' : '') ?>
                     <?= Button::info($createPageTitle)->icon('fa-plus')->sm()->link(Url::toWikiCreate($contentContainer))->visible($canCreate) ?>
                 </div>

--- a/widgets/PageListItemTitle.php
+++ b/widgets/PageListItemTitle.php
@@ -89,6 +89,10 @@ class PageListItemTitle extends Widget
             }
         }
 
+        $module = Yii::$app->getModule('wiki');        
+        $user = Yii::$app->user->identity;
+        $editingEnabled = $module->settings->contentContainer($user)->get('wikiTreeEditingEnabled', FALSE);
+
         return $this->render('pageListItemTitle', [
             'service' => $this->service,
             'item' => $this->item,
@@ -97,7 +101,7 @@ class PageListItemTitle extends Widget
             'titleInfo' => $this->titleInfo,
             'url' => $this->service->getWikiUrl($this->item),
             'icon' => $this->icon ?? $icon,
-            'showDrag' => $this->showDrag,
+            'showDrag' => $this->showDrag and $editingEnabled,
             'showAddPage' => $this->showAddPage,
             'options' => $this->getOptions(),
             'level' => $this->level,


### PR DESCRIPTION
With editor permissions in the Wiki tree structure, it is quite easy to move articles accidentially:
![image](https://github.com/user-attachments/assets/326ff62e-ee24-4180-adae-ebfa722aa91f)

A toggle button has been implemented in order to toggle between enabling and disabling editing the wiki tree structure. 
![Screenshot from 2025-04-01 20-16-51](https://github.com/user-attachments/assets/24a1cd8e-e8c9-4b13-814f-8ead5dd9ca85)
![Screenshot from 2025-04-01 20-17-09](https://github.com/user-attachments/assets/fb3f4e32-7e2b-4e2b-aabd-a123bc89092f)
